### PR TITLE
Compilation quick-fix for GHC-7.4.0.x

### DIFF
--- a/monad-par.cabal
+++ b/monad-par.cabal
@@ -1,5 +1,5 @@
 Name:                monad-par
-Version:             0.1.0.2
+Version:             0.1.0.3
 Synopsis:            A library for parallel programming based on a monad
 
 Description:         This library offers an alternative parallel programming


### PR DESCRIPTION
I noticed, that the deepseq bounds were bumped to accomodate deepseq-1.2 just two days ago... but in the mean-time deepseq got bumped again to 1.3.0.0 ...

It would be great, if a monad-par-0.1.0.3 could be uploaded soon, so that the GHC-7.4.0 snapshots can build monad-par out-of-the-box...
