### PR TITLE
Add explicit `Show` context constraint

### DIFF
--- a/Control/Monad/Par/Logging.hs
+++ b/Control/Monad/Par/Logging.hs
@@ -104,7 +104,7 @@ printAllLogs =
 ------------------------------------------------------------
 -- Helpers and Scrap:
 
-commaint :: Integral a => a -> String
+commaint :: (Show a, Integral a) => a -> String
 commaint n = 
    reverse $
    concat $


### PR DESCRIPTION
since starting with `base-4.5.0.0` `Num` instances aren't implicitly `Show`
instances as well anymore
