### PR TITLE
Guard a print statement with a dbg check

### DIFF
--- a/monad-par/Control/Monad/Par/Scheds/Direct.hs
+++ b/monad-par/Control/Monad/Par/Scheds/Direct.hs
@@ -841,9 +841,10 @@ busyTakeMVar :: String -> MVar a -> IO a
 busyTakeMVar msg mv = try (10 * 1000 * 1000)
  where 
  try 0 = do 
-   tid <- myThreadId
-   -- After we've failed enough times, start complaining:
-   printf "%s not getting anywhere, msg: %s\n" (show tid) msg  
+   when dbg $ do
+     tid <- myThreadId
+     -- After we've failed enough times, start complaining:
+     printf "%s not getting anywhere, msg: %s\n" (show tid) msg
    try (100 * 1000)
  try n = do
    x <- tryTakeMVar mv


### PR DESCRIPTION
busyTakeMVar seems to have a stray debugging statement in release 0.3.4.1.

I spawn many threads that intentionally wait for a long time, so this debugging message ends up being triggered quite a bit.
