### PR TITLE
Fix packages building with clang

### DIFF
--- a/Experimental/monad-par-data/Control/Monad/Par/Chan.hs
+++ b/Experimental/monad-par-data/Control/Monad/Par/Chan.hs
@@ -1,24 +1,23 @@
-{-# LANGUAGE FlexibleInstances, MultiParamTypeClasses, 
+{-# LANGUAGE FlexibleInstances, MultiParamTypeClasses,
              UndecidableInstances, TypeSynonymInstances, ScopedTypeVariables,
-	     EmptyDataDecls, CPP
-  #-}
-{-| 
+	           EmptyDataDecls, CPP #-}
+{-|
 
-UNFINISHED 
+UNFINISHED
 
     This module provides a basic implementation of channels that is
     usable with any monad satisfying ParIVar.
  -}
 
 
-module Control.Monad.Par.Chan 
+module Control.Monad.Par.Chan
  (
-   ParC, 
+   ParC,
 --    runParRNG, fork,
 --    IVar, new, newFull, newFull_, get, put, put_,
 --    spawn, spawn_
  )
- where 
+ where
 
 import qualified  Control.Monad.Par.Class as PC
 import Control.Monad.Trans
@@ -51,8 +50,8 @@ class SplittableState a where
 instance (SplittableState s, PC.ParFuture iv p)
       =>  PC.ParFuture iv (S.StateT s p) where
   get   = lift . PC.get
-  spawn_ (task :: S.StateT s p a) = 
-		  do s <- S.get 
+  spawn_ (task :: S.StateT s p a) =
+		  do s <- S.get
 		     let (s1,s2) = splitState s
 		     S.put s2
 		     let x  :: p (a,s) = S.runStateT task s1
@@ -66,8 +65,8 @@ instance (SplittableState s, PC.ParFuture iv p)
 --  spawn p  = do r <- new;  fork (p >>= put r);   return r
 --  spawn_ p = do r <- new;  fork (p >>= put_ r);  return r
 
-instance (SplittableState s, PC.ParIVar iv p) 
-      =>  PC.ParIVar iv (S.StateT s p) 
+instance (SplittableState s, PC.ParIVar iv p)
+      =>  PC.ParIVar iv (S.StateT s p)
  where
   fork     = fork
   new      = new
@@ -81,10 +80,10 @@ new      = lift  PC.new
 put  v x = lift$ PC.put  v x
 put_ v x = lift$ PC.put_ v x
 
-fork :: (SplittableState s, PC.ParIVar iv p) 
+fork :: (SplittableState s, PC.ParIVar iv p)
      => S.StateT s p () -> S.StateT s p ()
-fork task = 
-		do s <- S.get 
+fork task =
+		do s <- S.get
 		   let (s1,s2) = splitState s
 		   S.put s2
 		   lift$ PC.fork $ do
@@ -108,13 +107,13 @@ fork task =
 -- Let's do the safe one first:
 
 type Key = (Int, BitList)
--- genKey :: Monad m => ParC m Key 
+-- genKey :: Monad m => ParC m Key
 genKey = undefined
 
 --------------------------------------------------------------------------------
 
 -- A Par monad with stream support can be built from any other Par monad:
-type ParC p = S.StateT (CursorMap Magic) p 
+type ParC p = S.StateT (CursorMap Magic) p
 
 -- newtype CursorMap a = CursorMap (Vector (Cursor a))
 --data Cursor    a = Cursor Int (OpenList a)
@@ -125,7 +124,7 @@ newtype RecvPtr a = RecvPtr (Int, a)
 
 data Magic
 
-instance SplittableState (CursorMap a) where 
+instance SplittableState (CursorMap a) where
   splitState x = (x,x)
 
 -- type SendPort v a = ()
@@ -133,20 +132,20 @@ instance SplittableState (CursorMap a) where
 data SendPort a = SendPort a
 data RecvPort a = RecvPort a
 
-instance PC.ParIVar v m => PC.ParChan (ParC m) SendPort RecvPtr where 
+instance PC.ParIVar v m => PC.ParChan (ParC m) SendPort RecvPtr where
 
   -- A new channel coins a unique key that can be used to lookup the stream.
   newChan = undefined
   send    = undefined
 
   -- Advance the cursor:
-  recv (RecvPtr (i,_::elt)) = 
+  recv (RecvPtr (i,_::elt)) =
     -- The RecvPtr essentially carries the type, but no value for the stream.
-    do CursorMap vec <- S.get 
-       let ol = unsafeIndex vec i       
+    do CursorMap vec <- S.get
+       let ol = unsafeIndex vec i
            hd = L.head ol
 --       tl <- lift$ L.tail ol
---       V.modify (\v -> write v i tl) vec 
+--       V.modify (\v -> write v i tl) vec
 
 --       return hd
        return undefined

--- a/abstract-par/Control/Monad/Par/Class.hs
+++ b/abstract-par/Control/Monad/Par/Class.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE MultiParamTypeClasses, FunctionalDependencies, CPP,
-     FlexibleInstances, UndecidableInstances
-  #-}
+             FlexibleInstances, UndecidableInstances #-}
 -- UndecidableInstances
 
 {-|
@@ -9,7 +8,7 @@
     ('ParFuture') and full @IVars@ ('ParIVar').  All @Par@ monads are
     expected to implement the former, some also implement the latter.
 
-    For more documentation of the programming model, see  
+    For more documentation of the programming model, see
 
     * The "Control.Monad.Par" module in the @monad-par@ package.
 
@@ -22,15 +21,15 @@
     * Other slides (<http://www.cs.ox.ac.uk/ralf.hinze/WG2.8/28/slides/simon.pdf>, <http://www.cs.indiana.edu/~rrnewton/talks/2011_HaskellSymposium_ParMonad.pdf>)
 
  -}
---  
+--
 
-module Control.Monad.Par.Class 
-  (  
+module Control.Monad.Par.Class
+  (
   -- * Futures
     ParFuture(..)
   -- * IVars
   , ParIVar(..)
-  
+
     -- RRN: Not releasing this interface until there is a nice implementation of it:
     --  Channels (Streams)
     --  , ParChan(..)
@@ -46,14 +45,14 @@ import Control.DeepSeq
 -- | @ParFuture@ captures the class of Par monads which support
 --   futures.  This level of functionality subsumes @par@/@pseq@ and is
 --   similar to the "Control.Parallel.Strategies.Eval" monad.
--- 
+--
 --   A minimal implementation consists of `spawn_` and `get`.
 --   However, for monads that are also a member of `ParIVar` it is
 --   typical to simply define `spawn` in terms of `fork`, `new`, and `put`.
 class Monad m => ParFuture future m | m -> future where
   -- | Create a potentially-parallel computation, and return a /future/
   -- (or /promise/) that can be used to query the result of the forked
-  -- computataion.  
+  -- computataion.
   --
   -- >  spawn p = do
   -- >    r <- new
@@ -61,7 +60,7 @@ class Monad m => ParFuture future m | m -> future where
   -- >    return r
   --
   spawn  :: NFData a => m a -> m (future a)
-  
+
   -- | Like 'spawn', but the result is only head-strict, not fully-strict.
   spawn_ :: m a -> m (future a)
 
@@ -69,10 +68,10 @@ class Monad m => ParFuture future m | m -> future where
   get    :: future a -> m a
 
   -- | Spawn a pure (rather than monadic) computation.  Fully-strict.
-  -- 
+  --
   -- >  spawnP = spawn . return
   spawnP :: NFData a =>   a -> m (future a)
-  
+
   -- Default implementations:
   spawn  p = spawn_ (do x <- p; deepseq x (return x))
   spawnP a = spawn (return a)
@@ -82,17 +81,17 @@ class Monad m => ParFuture future m | m -> future where
 
 -- | @ParIVar@ builds on futures by adding full /anyone-writes, anyone-reads/ IVars.
 --   These are more expressive but may not be supported by all distributed schedulers.
--- 
+--
 -- A minimal implementation consists of `fork`, `put_`, and `new`.
 class ParFuture ivar m  => ParIVar ivar m | m -> ivar where
   -- | Forks a computation to happen in parallel.  The forked
   -- computation may exchange values with other computations using
   -- @IVar@s.
   fork :: m () -> m ()
-  
+
   -- | creates a new @IVar@
   new  :: m (ivar a)
-  
+
   -- | put a value into a @IVar@.  Multiple 'put's to the same @IVar@
   -- are not allowed, and result in a runtime error.
   --
@@ -106,26 +105,26 @@ class ParFuture ivar m  => ParIVar ivar m | m -> ivar where
   --
   put  :: NFData a => ivar a -> a -> m ()
   put v a = deepseq a (put_ v a)
-  
-  -- | like 'put', but only head-strict rather than fully-strict.  
+
+  -- | like 'put', but only head-strict rather than fully-strict.
   put_ :: ivar a -> a -> m ()
 
   -- Extra API routines that have default implementations:
-  
+
   -- | creates a new @IVar@ that contains a value
   newFull :: NFData a => a -> m (ivar a)
   newFull a = deepseq a (newFull_ a)
-  
+
   -- | creates a new @IVar@ that contains a value (head-strict only)
   newFull_ ::  a -> m (ivar a)
   newFull_ a = do v <- new
-                  -- This is usually inefficient! 
+                  -- This is usually inefficient!
 		  put_ v a
 		  return v
 
---------------------------------------------------------------------------------  
+--------------------------------------------------------------------------------
 
--- class ParYieldable ?? 
+-- class ParYieldable ??
   -- TODO: I think we should add yield officially:
 
   -- Allows other parallel computations to progress.  (should not be
@@ -159,12 +158,12 @@ class Monad m => ParChan snd rcv m | m -> snd, m -> rcv where
 -- t1 :: P.Par Int
 -- If the ParIVar => ParFuture instance exists the following is sufficient:
 t1 :: (ParFuture v m) => m Int
-t1 = do 
+t1 = do
   x <- spawn (return 3)
   get x
 
 t2 :: (ParIVar v m) => m Int
-t2 = do 
+t2 = do
   x <- new
   put x "hi"
   return 3
@@ -172,5 +171,5 @@ t2 = do
 
 -- TODO: SPECIALIZE generic routines for the default par monad (and possibly ParRNG)?
 
---  SPECIALISE parMap  :: (NFData b) => (a -> b)     -> [a] -> Par [b] 
--- SPECIALISE parMapM :: (NFData b) => (a -> Par b) -> [a] -> Par [b] 
+--  SPECIALISE parMap  :: (NFData b) => (a -> b)     -> [a] -> Par [b]
+-- SPECIALISE parMapM :: (NFData b) => (a -> Par b) -> [a] -> Par [b]

--- a/monad-par-extras/Control/Monad/Par/State.hs
+++ b/monad-par-extras/Control/Monad/Par/State.hs
@@ -1,6 +1,5 @@
-{-# LANGUAGE ScopedTypeVariables, FlexibleInstances, 
-     MultiParamTypeClasses, UndecidableInstances, CPP
-  #-}
+{-# LANGUAGE ScopedTypeVariables, FlexibleInstances,
+             MultiParamTypeClasses, UndecidableInstances, CPP #-}
 
 -- | This module provides a notion of (Splittable) State that is
 --   compatible with any Par monad.
@@ -8,7 +7,7 @@
 --   This module provides instances that make StateT-transformed
 --   monads into valid Par monads.
 
-module Control.Monad.Par.State 
+module Control.Monad.Par.State
   (
    SplittableState(..)
   )
@@ -27,7 +26,7 @@ import qualified Control.Monad.Trans.State.Lazy as SL
 -- | A type in `SplittableState` is meant to be added to a Par monad
 --   using StateT.  It works like any other state except at `fork`
 --   points, where the runtime system splits the state using `splitState`.
--- 
+--
 --   Common examples for applications of `SplittableState` would
 --   include (1) routing a splittable random number generator through
 --   a parallel computation, and (2) keeping a tree-index that locates
@@ -36,7 +35,7 @@ import qualified Control.Monad.Trans.State.Lazy as SL
 --   enabling "thread local" copies of the state.
 --
 --   The limitation of this approach is that the splitting method is
---   fixed, and the same at all `fork` points.  
+--   fixed, and the same at all `fork` points.
 class SplittableState a where
   splitState :: a -> (a,a)
 
@@ -44,22 +43,22 @@ class SplittableState a where
 -- Strict State:
 
 -- | Adding State to a `ParFuture` monad yields another `ParFuture` monad.
-instance (SplittableState s, PC.ParFuture fut p) 
-      =>  PC.ParFuture fut (S.StateT s p) 
+instance (SplittableState s, PC.ParFuture fut p)
+      =>  PC.ParFuture fut (S.StateT s p)
  where
   get = lift . PC.get
-  spawn_ (task :: S.StateT s p ans) = 
-    do s <- S.get 
+  spawn_ (task :: S.StateT s p ans) =
+    do s <- S.get
        let (s1,s2) = splitState s
        S.put s2                               -- Parent comp. gets one branch.
        lift$ PC.spawn_ $ S.evalStateT task s1   -- Child the other.
 
 -- | Likewise, adding State to a `ParIVar` monad yield s another `ParIVar` monad.
-instance (SplittableState s, PC.ParIVar iv p) 
-      =>  PC.ParIVar iv (S.StateT s p) 
+instance (SplittableState s, PC.ParIVar iv p)
+      =>  PC.ParIVar iv (S.StateT s p)
  where
-  fork (task :: S.StateT s p ()) = 
-              do s <- S.get 
+  fork (task :: S.StateT s p ()) =
+              do s <- S.get
                  let (s1,s2) = splitState s
                  S.put s2
                  lift$ PC.fork $ do S.runStateT task s1; return ()
@@ -71,8 +70,8 @@ instance (SplittableState s, PC.ParIVar iv p)
 -- ParChan not released yet:
 #if 0
 -- | Likewise, adding State to a `ParChan` monad yield s another `ParChan` monad.
-instance (SplittableState s, PC.ParChan snd rcv p) 
-      =>  PC.ParChan snd rcv (S.StateT s p) 
+instance (SplittableState s, PC.ParChan snd rcv p)
+      =>  PC.ParChan snd rcv (S.StateT s p)
  where
    newChan  = lift   PC.newChan
    recv   r = lift $ PC.recv r
@@ -86,22 +85,22 @@ instance (SplittableState s, PC.ParChan snd rcv p)
 -- <DUPLICATE_CODE>
 
 -- | Adding State to a `ParFuture` monad yield s another `ParFuture` monad.
-instance (SplittableState s, PC.ParFuture fut p) 
-      =>  PC.ParFuture fut (SL.StateT s p) 
+instance (SplittableState s, PC.ParFuture fut p)
+      =>  PC.ParFuture fut (SL.StateT s p)
  where
   get = lift . PC.get
-  spawn_ (task :: SL.StateT s p ans) = 
-    do s <- SL.get 
+  spawn_ (task :: SL.StateT s p ans) =
+    do s <- SL.get
        let (s1,s2) = splitState s
        SL.put s2                               -- Parent comp. gets one branch.
        lift$ PC.spawn_ $ SL.evalStateT task s1   -- Child the other.
 
 -- | Likewise, adding State to a `ParIVar` monad yield s another `ParIVar` monad.
-instance (SplittableState s, PC.ParIVar iv p) 
-      =>  PC.ParIVar iv (SL.StateT s p) 
+instance (SplittableState s, PC.ParIVar iv p)
+      =>  PC.ParIVar iv (SL.StateT s p)
  where
-  fork (task :: SL.StateT s p ()) = 
-              do s <- SL.get 
+  fork (task :: SL.StateT s p ()) =
+              do s <- SL.get
                  let (s1,s2) = splitState s
                  SL.put s2
                  lift$ PC.fork $ do SL.runStateT task s1; return ()
@@ -112,7 +111,7 @@ instance (SplittableState s, PC.ParIVar iv p)
 
 #if 0
 -- | Likewise, adding State to a `ParChan` monad yield s another `ParChan` monad.
-instance (SplittableState s, PC.ParChan snd rcv p) 
+instance (SplittableState s, PC.ParChan snd rcv p)
       =>  PC.ParChan snd rcv (SL.StateT s p)
  where
    newChan  = lift   PC.newChan

--- a/monad-par/Control/Monad/Par/Scheds/ContFree.hs
+++ b/monad-par/Control/Monad/Par/Scheds/ContFree.hs
@@ -1,11 +1,10 @@
 {-# LANGUAGE RankNTypes, NamedFieldPuns, BangPatterns,
              ExistentialQuantification, CPP, ScopedTypeVariables,
              TypeSynonymInstances, MultiParamTypeClasses,
-             GeneralizedNewtypeDeriving, RecordWildCards
-	     #-}
+             GeneralizedNewtypeDeriving, RecordWildCards #-}
 {-# OPTIONS_GHC -Wall -fno-warn-name-shadowing -fno-warn-unused-do-bind #-}
 
-{- | 
+{- |
 
   A monad-par tranfsormer which avoids continuation passing style by
   using actual IO threads to capture continuations (but only to
@@ -21,15 +20,15 @@
 
 
 module Control.Monad.Par.Scheds.ContFree (
-   Sched(..), Par, IVar(..), 
-    runPar, 
+   Sched(..), Par, IVar(..),
+    runPar,
     new, get, put_, fork,
     newFull, newFull_, put,
     spawn, spawn_, spawn1_, spawnP
  ) where
 
 
-import Control.Applicative 
+import Control.Applicative
 import Control.Concurrent hiding (yield)
 import Control.Monad.Cont as C
 import qualified Control.Monad.Reader as R
@@ -65,12 +64,12 @@ dbg = False
 --      ---------
 -- The ReaderT monad is there for retrieving the scheduler given the
 -- fact that the API calls do not get it as an argument.
--- 
+--
 newtype Par a = Par { unPar :: R.ReaderT Sched IO a }
     deriving (Monad, MonadIO, R.MonadReader Sched)
 
-data Sched = Sched 
-    { 
+data Sched = Sched
+    {
       ---- Per worker ----
       no       :: {-# UNPACK #-} !Int,
       workpool :: HotVar (Deque (Par ())),
@@ -86,7 +85,7 @@ data Sched = Sched
 
 newtype IVar a = IVar (IORef (IVarContents a))
 
-data IVarContents a = Full a | Empty | Blocked (MVar a) 
+data IVarContents a = Full a | Empty | Blocked (MVar a)
   -- | Future a
 
 
@@ -99,7 +98,7 @@ data IVarContents a = Full a | Empty | Blocked (MVar a)
 
 casIORef = undefined
 
-emptydeque :: Deque a 
+emptydeque :: Deque a
 addfront  :: a -> Deque a -> Deque a
 addback   :: a -> Deque a -> Deque a
 
@@ -114,24 +113,24 @@ dqlen :: Deque a -> Int
 newtype Deque a = DQ [a]
 emptydeque = DQ []
 
-addfront x (DQ l)    = -- trace (" * addfront brought queue up to: " ++ show (length (x:l))) $ 
+addfront x (DQ l)    = -- trace (" * addfront brought queue up to: " ++ show (length (x:l))) $
 		       DQ (x:l)
 addback x (DQ [])    = DQ [x]
 addback x (DQ (h:t)) = DQ (h : rest)
  where DQ rest = addback x (DQ t)
 
 takefront (DQ [])     = (emptydeque, Nothing)
-takefront (DQ (x:xs)) = -- trace (" * takefront popped one, remaining: " ++ show (length xs)) $ 
+takefront (DQ (x:xs)) = -- trace (" * takefront popped one, remaining: " ++ show (length xs)) $
 			(DQ xs, Just x)
 takeback  (DQ [])     = (emptydeque, Nothing)
-takeback  (DQ ls)     = -- trace (" * takeback popped one, remaining: " ++ show (length rest)) $ 
+takeback  (DQ ls)     = -- trace (" * takeback popped one, remaining: " ++ show (length rest)) $
 			(DQ rest, Just final)
- where 
+ where
   (final,rest) = loop ls []
   loop [x]    acc = (x, reverse acc)
   loop (h:tl) acc = loop tl (h:acc)
   loop []     _   = error "this shouldn't happen"
- 
+
 dqlen (DQ l) = length l
 #endif
 
@@ -164,7 +163,7 @@ modifyHotVar  = atomicModifyIORef
 modifyHotVar_ v fn = atomicModifyIORef v (\a -> (fn a, ()))
 readHotVar    = readIORef
 writeHotVar   = writeIORef
-instance Show (IORef a) where 
+instance Show (IORef a) where
   show ref = "<ioref>"
 
 -- hotVarTransaction = id
@@ -173,7 +172,7 @@ readHotVarRaw  = readHotVar
 writeHotVarRaw = writeHotVar
 
 
-#elif HOTVAR == 2 
+#elif HOTVAR == 2
 #warning "Using MVars for hot atomic variables."
 -- This uses MVars that are always full with *something*
 type HotVar a = MVar a
@@ -182,7 +181,7 @@ modifyHotVar  v fn = modifyMVar  v (return . fn)
 modifyHotVar_ v fn = modifyMVar_ v (return . fn)
 readHotVar    = readMVar
 writeHotVar v x = do swapMVar v x; return ()
-instance Show (MVar a) where 
+instance Show (MVar a) where
   show ref = "<mvar>"
 
 -- hotVarTransaction = id
@@ -198,14 +197,14 @@ writeHotVarRaw = writeHotVar
 -- Simon Marlow said he saw better scaling with TVars (surprise to me):
 type HotVar a = TVar a
 newHotVar = newTVarIO
-modifyHotVar  tv fn = atomically (do x <- readTVar tv 
+modifyHotVar  tv fn = atomically (do x <- readTVar tv
 				     let (x2,b) = fn x
 				     writeTVar tv x2
 				     return b)
 modifyHotVar_ tv fn = atomically (do x <- readTVar tv; writeTVar tv (fn x))
 readHotVar x = atomically $ readTVar x
 writeHotVar v x = atomically $ writeTVar v x
-instance Show (TVar a) where 
+instance Show (TVar a) where
   show ref = "<tvar>"
 
 hotVarTransaction = atomically
@@ -220,7 +219,7 @@ writeHotVarRaw = writeTVar
 
 {-# INLINE popWork  #-}
 popWork :: Sched -> IO (Maybe (Par ()))
-popWork Sched{ workpool } = 
+popWork Sched{ workpool } =
   modifyHotVar  workpool  takefront
 
 {-# INLINE pushWork #-}
@@ -251,7 +250,7 @@ rand ref = uniformR (0, numCapabilities-1) =<< readHotVar ref
 
 runPar userComp = unsafePerformIO $ do
    allscheds <- makeScheds
-  
+
 #if __GLASGOW_HASKELL__ >= 701 /* 20110301 */
     --
     -- We create a thread on each CPU with forkOnIO.  The CPU on which
@@ -279,18 +278,18 @@ runPar userComp = unsafePerformIO $ do
         forkOnIO cpu $
           if (cpu /= main_cpu)
              then do when dbg$ printf "CPU %d entering scheduling loop.\n" cpu
-		     R.runReaderT enterScheduler sched 
+		     R.runReaderT enterScheduler sched
 		     when dbg$ printf "    CPU %d exited scheduling loop.  FINISHED.\n" cpu
              else do
                   rref <- newIORef Empty
 		  let userComp'  = do when dbg$ liftIO$ printf "Starting Par computation on main thread (%d).\n" main_cpu
 				      res <- userComp
-                                      finalSched <- R.ask 
+                                      finalSched <- R.ask
 				      when dbg$ liftIO$ printf "Out of Par computation on thread (%d).\n" (no finalSched)
 #ifdef DEBUG
 				      liftIO$ putStrLn$ "Result was " ++ (show res)
 #endif
-                                      -- If we are not purely continuation-stealing that means we may 
+                                      -- If we are not purely continuation-stealing that means we may
 				      -- get to this point and have work left in our queue.  We need to reschedule.
                                       dq <- liftIO$ readHotVar (workpool finalSched)
                                       when (dqlen dq > 0) $ do
@@ -298,17 +297,17 @@ runPar userComp = unsafePerformIO $ do
 					 Par enterScheduler
 
                                       when dbg$ liftIO$ putStrLn "MAIN THREAD ABOUT TO FORCE THE FINAL RESULT."
-                                      -- After that we know that this worker has done all its work.  
-				      -- However, if there's anyone else unfinished we may still 
+                                      -- After that we know that this worker has done all its work.
+				      -- However, if there's anyone else unfinished we may still
 				      -- block on "res" in the following put, which is fine.
 				      put_ (IVar rref) res
-		  
+
 		  R.runReaderT (unPar userComp') sched
 
                   when dbg$ printf " *** Completely out of users computation.  Writing final value to MVar %d\n" (hashStableName sn)
                   readIORef rref >>= putMVar mv
-   
-   when dbg$ do 
+
+   when dbg$ do
       printf " *** Main thread about to take final result from MVar %d\n" (hashStableName sn)
    r <- takeMVar mv
    case r of
@@ -320,45 +319,45 @@ runPar userComp = unsafePerformIO $ do
 -- Create the default scheduler(s) state:
 makeScheds = do
    workpools <- replicateM numCapabilities $ newHotVar emptydeque
-   rngs      <- replicateM numCapabilities $ Random.create >>= newHotVar 
-   idle <- newHotVar []   
+   rngs      <- replicateM numCapabilities $ Random.create >>= newHotVar
+   idle <- newHotVar []
    killflag <- newHotVar False
    mortals  <- mapM newHotVar (replicate numCapabilities Set.empty)
-   let states = [ Sched { no=x, idle, killflag, 
+   let states = [ Sched { no=x, idle, killflag,
 			  workpool=wp, scheds=states, rng=rng,
-			  mortal 
+			  mortal
 			}
-                | ((x,wp),(rng,mortal)) <- zip (zip [0..] workpools) 
+                | ((x,wp),(rng,mortal)) <- zip (zip [0..] workpools)
 		                               (zip rngs mortals)]
    return states
 
 
-regulatePopulation Sched{..} = 
-  do 
+regulatePopulation Sched{..} =
+  do
      return ()
 
 replaceWorker :: Sched -> IO ThreadId
-replaceWorker sch@Sched{no} = do 
+replaceWorker sch@Sched{no} = do
   -- EXPERIMENTAL: Because our deques are threadsafe on both ends we
-  -- can try just reusing the same Sched structure.  
+  -- can try just reusing the same Sched structure.
   --   We use forkOnIO to stay on the same processor as the thread we
   -- are replacing.  Therefore we expect no contention from our Sched
   -- reuse because the reusing thread is on the same physical core.
-  -- 
+  --
   -- We do need to change the identifying 'no' though and thereforewe
   -- copy the Sched structure.  (We advance our 'no' by
   -- numCapabilities to avoid collision.)
-  -- 
+  --
   -- TODO: Compare this partial reuse of the Sched structure to just
-  -- allocating a completely fresh one. 
-  -- 
+  -- allocating a completely fresh one.
+  --
   when dbg $ liftIO$ printf " [%d] Replacing with worker %d\n" no (no+numCapabilities)
   forkOnIO no (R.runReaderT enterScheduler sch{no= no + numCapabilities})
 
 -- Register the current thread as being already replaced.
-makeMortal sch@Sched{no, mortal} = 
+makeMortal sch@Sched{no, mortal} =
   modifyHotVar_ mortal (Set.insert no)
-  
+
 
 --------------------------------------------------------------------------------
 -- IVar operations
@@ -375,21 +374,21 @@ spinReadMVar :: Sched -> MVar b -> IO b
 spinReadMVar Sched{..} mv = do
   sn <- makeStableName mv
   let loop = do v <- tryTakeMVar mv
-		case v of 
-		  Nothing -> do printf "                 [%d] thread spinning to try to read MVar %d\n" no (hashStableName sn) 
+		case v of
+		  Nothing -> do printf "                 [%d] thread spinning to try to read MVar %d\n" no (hashStableName sn)
 				threadDelay (100 * 1000) -- 1/10 a second
-				loop 
-		  Just x -> do printf "[%d] SUCCESSFULLY read MVar %d\n" no (hashStableName sn) 
+				loop
+		  Just x -> do printf "[%d] SUCCESSFULLY read MVar %d\n" no (hashStableName sn)
 			       putMVar mv x
 			       return x
   loop
-		  
+
 
 {-# INLINE get  #-}
 -- | read the value in a @IVar@.  The 'get' can only return when the
 -- value has been written by a prior or parallel @put@ to the same
 -- @IVar@.
-get (IVar v) = do 
+get (IVar v) = do
        -- Optimistically read without writing, maybe the value is already there:
        e  <- liftIO$ readIORef v
        case e of
@@ -400,8 +399,8 @@ get (IVar v) = do
             sch <- R.ask
             mv <- liftIO$ newEmptyMVar
 	    sn <- liftIO$ makeStableName mv
-            let rd mv x = 
-                   let 
+            let rd mv x =
+                   let
 #ifdef DEBUG
 		       act = spinReadMVar sch mv
 #else
@@ -415,15 +414,15 @@ get (IVar v) = do
             when dbg$ liftIO$ printf "  It looks like we may go down to block MVar %d for a get.  Thread %d\n" (hashStableName sn) (no sch)
 
 	    -- The thread modifying the IO ref will block until the MVar is filled in:
-	    val <- liftIO$ atomicModifyIORef v $ \e -> 
+	    val <- liftIO$ atomicModifyIORef v $ \e ->
 	     case e of
 	       Empty         -> rd mv (Blocked mv)
 	       x@(Full a)    -> (x, a) -- This happened 1114 times on fib(24)
-	       x@(Blocked mv) -> rd mv x 
+	       x@(Blocked mv) -> rd mv x
             -- Make sure that we have the actual value (not just a thunk) before proceding:
 #ifdef DEBUG
             trace (" !! performing unsafeIO read of MVar "++ show (hashStableName sn) ++"... thread "++ show (no sch)) $
-             val `pseq` 
+             val `pseq`
               trace (" !! COMPLETED read of MVar "++ show (hashStableName sn) ++" on thread "++ show (no sch) ++ " value " ++ show val) $
               (return val)
 #else
@@ -440,17 +439,17 @@ put_ (IVar v) !content = do
    sn <- liftIO$ makeStableName v
    when dbg$ liftIO$ printf "    !! [%d] PUTTING value %s to ivar %d\n" (no sched) (show content) (hashStableName sn)
 #endif
-   liftIO$ do 
+   liftIO$ do
       mmv <- atomicModifyIORef v $ \e -> case e of
                Empty      -> (Full content, Nothing)
                Blocked mv -> (Full content, Just mv)
                Full _     -> error "multiple put"
-      case mmv of 
-        Just mv -> do 
+      case mmv of
+        Just mv -> do
 		      when dbg$ do sn <- makeStableName mv
 				   printf "    !! [thread %d] Putting MVar %d, unblocking thread(s).\n"  (hashStableName sn) (no sched)
 		      putMVar mv content
-        Nothing -> return () 
+        Nothing -> return ()
 
 {-# INLINE fork #-}
 fork :: Par () -> Par ()
@@ -462,7 +461,7 @@ fork task = do
 -- enterScheduler is the main entrypoint for the scheduler.
 enterScheduler :: R.ReaderT Sched IO ()
 enterScheduler = do
-  mysched <- R.ask 
+  mysched <- R.ask
   when dbg$ liftIO$ printf " - Reschedule: CPU %d\n" (no mysched)
   mtask <- liftIO$ popWork mysched
   case mtask of
@@ -471,17 +470,17 @@ enterScheduler = do
        -- When popping work from our own queue the Sched (Reader value) stays the same:
        when dbg $ liftIO$ printf "  popped work from own queue (cpu %d)\n" (no mysched)
        -- Run the stolen tasK:
-       unPar task 
+       unPar task
        when dbg$ do sch <- R.ask; liftIO$ printf "  + task finished successfully on cpu %d\n" (no sch)
-       -- Before going around again, we check if we have become "mortal": 
+       -- Before going around again, we check if we have become "mortal":
        mortset <- liftIO$ readHotVar (mortal mysched)
        if Set.member (no mysched) mortset then
           when dbg$ liftIO$ printf " [%d] Thread is mortal, shutting down.\n" (no mysched)
-        else enterScheduler 
-   
+        else enterScheduler
+
 -- | Attempt to steal work or, failing that, give up and go idle.
 steal :: Sched -> IO ()
-steal mysched@Sched{ idle, scheds, rng, no=my_no } = do 
+steal mysched@Sched{ idle, scheds, rng, no=my_no } = do
   when dbg$ printf "cpu %d stealing\n" my_no
   i <- rand rng  -- Pick an initial victim.
   go maxtries i
@@ -494,7 +493,7 @@ steal mysched@Sched{ idle, scheds, rng, no=my_no } = do
 
     ----------------------------------------
     -- IDLING behavior:
-    go 0 _ = 
+    go 0 _ =
             do mv <- newEmptyMVar
                when dbg$ printf "cpu %d Tired of stealing... giving up.\n" my_no
                r <- modifyHotVar idle $ \is -> (mv:is, is)
@@ -521,20 +520,20 @@ steal mysched@Sched{ idle, scheds, rng, no=my_no } = do
 			go (tries-1) i'
 
       | otherwise     = do
-         let schd = scheds!!i -- TEMP, FIXME, linear access of a list. 
+         let schd = scheds!!i -- TEMP, FIXME, linear access of a list.
          when dbg$ printf "cpu %d trying steal from %d\n" my_no (no schd)
 
          r <- modifyHotVar (workpool schd) takeback
          case r of
            Just task  -> do
               when dbg$ printf "cpu %d got work from cpu %d\n" my_no (no schd)
-	      R.runReaderT (unPar task) mysched 
-           Nothing -> do i' <- rand rng 
+	      R.runReaderT (unPar task) mysched
+           Nothing -> do i' <- rand rng
 			 go (tries-1) i'
 
 {-# INLINE spawn1_ #-}
 -- Spawn a one argument function instead of a thunk.  This is good for debugging if the value supports "Show".
-spawn1_ f x = 
+spawn1_ f x =
 #ifdef DEBUG
  do sch <- R.ask; when dbg$ liftIO$ printf " [%d] spawning fn with arg %s\n" (no sch) (show x)
 #endif
@@ -544,7 +543,7 @@ spawn1_ f x =
 ----------------------------------------------------------------------------------------------------
 -- TEMPORARY -- SCRAP:
 
--- The following is usually inefficient! 
+-- The following is usually inefficient!
 newFull_ a = do v <- new
 		put_ v a
 		return v
@@ -577,7 +576,7 @@ spawn  :: (Show a, NFData a) => Par a -> Par (IVar a)
 spawn_ :: Show a => Par a -> Par (IVar a)
 put_   :: Show a => IVar a -> a -> Par ()
 get    :: Show a => IVar a -> Par a
-runPar :: Show a => Par a -> a 
+runPar :: Show a => Par a -> a
 newFull_ ::  Show a => a -> Par (IVar a)
 #else
 spawn  :: NFData a => Par a -> Par (IVar a)
@@ -585,7 +584,7 @@ spawn_ :: Par a -> Par (IVar a)
 put_   :: IVar a -> a -> Par ()
 put    :: NFData a => IVar a -> a -> Par ()
 get    :: IVar a -> Par a
-runPar :: Par a -> a 
+runPar :: Par a -> a
 newFull_ ::  a -> Par (IVar a)
 
 instance PC.ParFuture IVar Par where

--- a/monad-par/Control/Monad/Par/Scheds/DirectInternal.hs
+++ b/monad-par/Control/Monad/Par/Scheds/DirectInternal.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE PackageImports, CPP, 
-    GeneralizedNewtypeDeriving 
- #-}
+{-# LANGUAGE PackageImports, CPP, GeneralizedNewtypeDeriving #-}
 
 -- | Type definiton and some helpers.  This is used mainly by
 -- Direct.hs but can also be used by other modules that want access to
@@ -38,7 +36,7 @@ import Data.Concurrent.Deque.Reference as R
 --      ---------
 -- The ReaderT monad is there for retrieving the scheduler given the
 -- fact that the API calls do not get it as an argument.
--- 
+--
 -- Note that the result type for continuations is unit.  Forked
 -- computations return nothing.
 --
@@ -51,28 +49,28 @@ type SessionID = Word64
 -- An ID along with a flag to signal completion:
 data Session = Session SessionID (HotVar Bool)
 
-data Sched = Sched 
-    { 
+data Sched = Sched
+    {
       ---- Per worker ----
       no       :: {-# UNPACK #-} !Int,
       workpool :: WSDeque (Par ()),
       rng      :: HotVar Random.GenIO, -- Random number gen for work stealing.
-      isMain :: Bool, -- Are we the main/master thread? 
+      isMain :: Bool, -- Are we the main/master thread?
 
       -- The stack of nested sessions that THIS worker is participating in.
       -- When a session finishes, the worker can return to its Haskell
       -- calling context (it's "real" continuation).
       sessions :: HotVar [Session],
       -- (1) This is always non-empty, containing at least the root
-      --     session corresponding to the anonymous system workers.      
+      --     session corresponding to the anonymous system workers.
       -- (2) The original invocation of runPar also counts as a session
-      --     and pushes a second 
+      --     and pushes a second
       -- (3) Nested runPar invocations may push further sessions onto the stack.
-            
+
       ---- Global data: ----
       idle     :: HotVar [MVar Bool], -- waiting idle workers
       scheds   :: [Sched],            -- A global list of schedulers.
-      
+
       -- Any thread that enters runPar (original or nested) registers
       -- itself in this global list.  When the list becomes null,
       -- worker threads may shut down or at least go idle.
@@ -113,7 +111,7 @@ modifyHotVar  = atomicModifyIORef
 modifyHotVar_ v fn = atomicModifyIORef v (\a -> (fn a, ()))
 readHotVar    = readIORef
 writeHotVar   = writeIORef
-instance Show (IORef a) where 
+instance Show (IORef a) where
   show ref = "<ioref>"
 
 -- hotVarTransaction = id
@@ -122,7 +120,7 @@ readHotVarRaw  = readHotVar
 writeHotVarRaw = writeHotVar
 
 
-#elif HOTVAR == 2 
+#elif HOTVAR == 2
 #warning "Using MVars for hot atomic variables."
 -- This uses MVars that are always full with *something*
 type HotVar a = MVar a
@@ -131,7 +129,7 @@ modifyHotVar  v fn = modifyMVar  v (return . fn)
 modifyHotVar_ v fn = modifyMVar_ v (return . fn)
 readHotVar    = readMVar
 writeHotVar v x = do swapMVar v x; return ()
-instance Show (MVar a) where 
+instance Show (MVar a) where
   show ref = "<mvar>"
 
 -- hotVarTransaction = id
@@ -147,14 +145,14 @@ writeHotVarRaw = writeHotVar
 -- Simon Marlow said he saw better scaling with TVars (surprise to me):
 type HotVar a = TVar a
 newHotVar = newTVarIO
-modifyHotVar  tv fn = atomically (do x <- readTVar tv 
+modifyHotVar  tv fn = atomically (do x <- readTVar tv
 				     let (x2,b) = fn x
 				     writeTVar tv x2
 				     return b)
 modifyHotVar_ tv fn = atomically (do x <- readTVar tv; writeTVar tv (fn x))
 readHotVar x = atomically $ readTVar x
 writeHotVar v x = atomically $ writeTVar v x
-instance Show (TVar a) where 
+instance Show (TVar a) where
   show ref = "<tvar>"
 
 hotVarTransaction = atomically

--- a/monad-par/Control/Monad/Par/Scheds/SerialElision.hs
+++ b/monad-par/Control/Monad/Par/Scheds/SerialElision.hs
@@ -1,9 +1,7 @@
-{-# LANGUAGE RankNTypes, ImpredicativeTypes, MultiParamTypeClasses, 
-             CPP
-   #-}
+{-# LANGUAGE RankNTypes, ImpredicativeTypes, MultiParamTypeClasses, CPP #-}
 
 -- | This is a sequential implementation of the Par monad.
--- 
+--
 --   It only works for the subset of programs in which a
 --   top-to-bottom/left-to-right execution of the program writes all
 --   IVars before reading them.  It is analogous to the Cilk notion of
@@ -39,7 +37,7 @@ unP (P x) = x
 
 -- The newtype's above were necessary for the 'ParIVar'/'ParFuture'
 -- instance below and thus we need a Monad instance as well:
-instance Monad Par where 
+instance Monad Par where
   (P m) >>= f = P (m >>= unP . f)
   return x = P (return x)
 
@@ -65,17 +63,17 @@ newFull_ x = P$ newIORef (Just x)             >>= return . I
 
 get (I r) = P$
         do x <- readIORef r
-	   case x of 
+	   case x of
              -- TODO: Could keep track of pedigree for better errors:
 	     Nothing -> error "IVar read before written!"
-	     Just y  -> return y 
+	     Just y  -> return y
 
 put  (I r) x = rnf x `seq` P (writeIORef r (Just x))
 put_ (I r) x = P$ writeIORef r (Just x)
 
-runPar (P m) = 
+runPar (P m) =
   trace ("ParElision: Running with unsafeIO...")
-  unsafePerformIO m 
+  unsafePerformIO m
 
 
 ----------------------------------------------------------------------------------------------------

--- a/monad-par/Control/Monad/Par/Scheds/Trace.hs
+++ b/monad-par/Control/Monad/Par/Scheds/Trace.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE RankNTypes, NamedFieldPuns, BangPatterns,
-             ExistentialQuantification, MultiParamTypeClasses, CPP
-	     #-}
+             ExistentialQuantification, MultiParamTypeClasses, CPP #-}
 {- OPTIONS_GHC -Wall -fno-warn-name-shadowing -fwarn-unused-imports -}
 
 {- | This is the scheduler described in the paper "A Monad for
@@ -13,7 +12,7 @@
 module Control.Monad.Par.Scheds.Trace (
     Par, runPar, runParIO, fork,
     IVar, new, newFull, newFull_, get, put, put_,
-    spawn, spawn_, spawnP 
+    spawn, spawn_, spawnP
   ) where
 
 import qualified Control.Monad.Par.Class as PC
@@ -46,8 +45,8 @@ instance PC.ParFuture IVar Par  where
   spawn_ = spawn_
   spawnP = spawnP
 
-instance PC.ParIVar IVar Par  where 
-  fork = fork 
+instance PC.ParIVar IVar Par  where
+  fork = fork
   new  = new
   put  = put
   put_ = put_

--- a/monad-par/Control/Monad/Par/Scheds/TraceInternal.hs
+++ b/monad-par/Control/Monad/Par/Scheds/TraceInternal.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE RankNTypes, NamedFieldPuns, BangPatterns,
-             ExistentialQuantification, CPP
-	     #-}
+             ExistentialQuantification, CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-name-shadowing -fno-warn-unused-do-bind #-}
 
 -- | This module exposes the internals of the @Par@ monad so that you
@@ -41,7 +40,7 @@ data Trace = forall a . Get (IVar a) (a -> Trace)
 -- | The main scheduler loop.
 sched :: Bool -> Sched -> Trace -> IO ()
 sched _doSync queue t = loop t
- where 
+ where
   loop t = case t of
     New a f -> do
       r <- newIORef a
@@ -77,7 +76,7 @@ sched _doSync queue t = loop t
 -- threads work-queue because it can be stolen by other threads.
 --	 else return ()
 
-    Yield parent -> do 
+    Yield parent -> do
         -- Go to the end of the worklist:
         let Sched { workpool } = queue
         -- TODO: Perhaps consider Data.Seq here.
@@ -180,9 +179,9 @@ instance NFData (IVar a) where
 
 -- From outside the Par computation we can peek.  But this is nondeterministic.
 pollIVar :: IVar a -> IO (Maybe a)
-pollIVar (IVar ref) = 
+pollIVar (IVar ref) =
   do contents <- readIORef ref
-     case contents of 
+     case contents of
        Full x -> return (Just x)
        _      -> return (Nothing)
 
@@ -244,7 +243,7 @@ runParIO = runPar_internal True
 
 -- | An asynchronous version in which the main thread of control in a
 -- Par computation can return while forked computations still run in
--- the background.  
+-- the background.
 runParAsync :: Par a -> a
 runParAsync = unsafePerformIO . runPar_internal False
 

--- a/monad-par/Control/Monad/Par_Strawman.hs
+++ b/monad-par/Control/Monad/Par_Strawman.hs
@@ -1,9 +1,8 @@
 {-# LANGUAGE RankNTypes, NamedFieldPuns, BangPatterns,
-             ExistentialQuantification, CPP
-	     #-}
+             ExistentialQuantification, CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-name-shadowing -fwarn-unused-imports #-}
 
-{- 
+{-
 
   This alternate implementation of Par uses the existing thread/MVar
   capabilities of GHC.  It therefore represents an attempt to do
@@ -39,7 +38,7 @@ import Control.Applicative
 -- import Text.Printf
 
 -- For testing only:
-import Test.HUnit 
+import Test.HUnit
 import Control.Exception
 
 
@@ -116,27 +115,27 @@ parMapM f xs = mapM (spawn . f) xs >>= mapM get
 
 
 -- | parMapReduceRange is similar to the "parallel for" construct
---   found in many parallel programming models.  
--- 
+--   found in many parallel programming models.
+--
 parMapReduceRange :: NFData a => Int -> Int -> Int -> (Int -> Par a) -> (a -> a -> Par a) -> a -> Par a
-parMapReduceRange threshold min max fn binop init = loop min max 
- where 
-  loop min max 
-    | max - min <= threshold = 
-	let mapred a b = do x <- fn b; 
+parMapReduceRange threshold min max fn binop init = loop min max
+ where
+  loop min max
+    | max - min <= threshold =
+	let mapred a b = do x <- fn b;
 			    result <- a `binop` x
-			    return result 
+			    return result
 	in foldM mapred init [min..max]
 
     | otherwise  = do
 	let mid = min + ((max - min) `quot` 2)
-	rght <- spawn $ loop (mid+1) max 
-	l  <- loop  min    mid 
+	rght <- spawn $ loop (mid+1) max
+	l  <- loop  min    mid
 	r  <- get rght
 	lr <- l `binop` r
 	return lr
 
 -- TODO: A version that works for any splittable input domain.  In this case
 -- the "threshold" is a predicate on inputs.
--- parMapReduceRangeGeneric :: (inp -> Bool) -> (inp -> Maybe (inp,inp)) -> inp -> 
+-- parMapReduceRangeGeneric :: (inp -> Bool) -> (inp -> Maybe (inp,inp)) -> inp ->
 


### PR DESCRIPTION
" #-}" is interpreted as unknown pragma by clang preprocessor, so fix package building in some cases, on os x mavericks for example.

Also automatically removed some trailing spaces
