### PR TITLE
Move Source-repository out of Library section to prevent warning

### DIFF
--- a/monad-par/monad-par.cabal
+++ b/monad-par/monad-par.cabal
@@ -85,11 +85,11 @@ Flag newgeneric
    Description: Provide instances for the new par-classes generic Par programming interface.
    Default: False
 
-Library
-  Source-repository head
-    type:     git
-    location: https://github.com/simonmar/monad-par
+Source-repository head
+  type:     git
+  location: https://github.com/simonmar/monad-par
 
+Library
   Exposed-modules: 
                  -- The classic, simple monad-par interface:
                    Control.Monad.Par


### PR DESCRIPTION
This patch fixes the warnings we see in `cabal configure`:

```
% cabal configure
Warning: monad-par.cabal: Unexpected section 'source-repository' on line 89
Resolving dependencies...
Warning: monad-par.cabal: Unexpected section 'source-repository' on line 89
Configuring monad-par-0.3.4.6...
```
