### PR TITLE
Documentation improvements

### DIFF
--- a/monad-par/Control/Monad/Par.hs
+++ b/monad-par/Control/Monad/Par.hs
@@ -97,7 +97,7 @@ module Control.Monad.Par
   runPar, runParIO,
 
   fork,
-  -- | forks a computation to happen in parallel.  The forked
+  -- | Forks a computation to happen in parallel.  The forked
   -- computation may exchange values with other computations using
   -- @IVar@s.
 

--- a/monad-par/Control/Monad/Par.hs
+++ b/monad-par/Control/Monad/Par.hs
@@ -119,7 +119,7 @@ module Control.Monad.Par
   -- @IVar@.
 
   put, 
-  -- | put a value into a @IVar@.  Multiple 'put's to the same @IVar@
+  -- | put a value into an @IVar@.  Multiple 'put's to the same @IVar@
   -- are not allowed, and result in a runtime error.
   --
   -- 'put' fully evaluates its argument, which therefore must be an
@@ -136,7 +136,7 @@ module Control.Monad.Par
 
   -- * Operations
   spawn,
-  -- | Like 'fork', but returns a @IVar@ that can be used to query the
+  -- | Like 'fork', but returns an @IVar@ that can be used to query the
   -- result of the forked computataion.  Therefore @spawn@ provides /futures/ or /promises/.
   --
   -- >  spawn p = do

--- a/monad-par/Control/Monad/Par.hs
+++ b/monad-par/Control/Monad/Par.hs
@@ -105,21 +105,21 @@ module Control.Monad.Par
   IVar,
 
   new, 
-  -- | creates a new @IVar@
+  -- creates a new @IVar@
 
   newFull, 
-  -- | creates a new @IVar@ that contains a value
+  -- creates a new @IVar@ that contains a value
 
   newFull_, 
-  -- | creates a new @IVar@ that contains a value (head-strict only)
+  -- creates a new @IVar@ that contains a value (head-strict only)
 
   get, 
-  -- | read the value in an @IVar@.  'get' can only return when the
+  -- read the value in an @IVar@.  'get' can only return when the
   -- value has been written by a prior or parallel @put@ to the same
   -- @IVar@.
 
   put, 
-  -- | put a value into an @IVar@.  Multiple 'put's to the same @IVar@
+  -- put a value into an @IVar@.  Multiple 'put's to the same @IVar@
   -- are not allowed, and result in a runtime error.
   --
   -- 'put' fully evaluates its argument, which therefore must be an
@@ -132,7 +132,7 @@ module Control.Monad.Par
   --
 
   put_,
-  -- | like 'put', but only head-strict rather than fully-strict.
+  -- like 'put', but only head-strict rather than fully-strict.
 
   -- * Operations
   spawn,

--- a/monad-par/Control/Monad/Par/Scheds/ContFree.hs
+++ b/monad-par/Control/Monad/Par/Scheds/ContFree.hs
@@ -364,7 +364,7 @@ makeMortal sch@Sched{no, mortal} =
 --------------------------------------------------------------------------------
 
 {-# INLINE new  #-}
--- | creates a new @IVar@
+-- | Creates a new @IVar@
 new :: Par (IVar a)
 new  = liftIO $ do r <- newIORef Empty
                    return (IVar r)
@@ -385,7 +385,7 @@ spinReadMVar Sched{..} mv = do
 
 
 {-# INLINE get  #-}
--- | read the value in an @IVar@.  The 'get' can only return when the
+-- | Read the value in an @IVar@.  The 'get' can only return when the
 -- value has been written by a prior or parallel @put@ to the same
 -- @IVar@.
 get (IVar v) = do

--- a/monad-par/Control/Monad/Par/Scheds/ContFree.hs
+++ b/monad-par/Control/Monad/Par/Scheds/ContFree.hs
@@ -385,7 +385,7 @@ spinReadMVar Sched{..} mv = do
 
 
 {-# INLINE get  #-}
--- | Read the value in an @IVar@.  The 'get' can only return when the
+-- | Read the value in an @IVar@.  The 'get' operation can only return when the
 -- value has been written by a prior or parallel @put@ to the same
 -- @IVar@.
 get (IVar v) = do

--- a/monad-par/Control/Monad/Par/Scheds/ContFree.hs
+++ b/monad-par/Control/Monad/Par/Scheds/ContFree.hs
@@ -385,7 +385,7 @@ spinReadMVar Sched{..} mv = do
 
 
 {-# INLINE get  #-}
--- | read the value in a @IVar@.  The 'get' can only return when the
+-- | read the value in an @IVar@.  The 'get' can only return when the
 -- value has been written by a prior or parallel @put@ to the same
 -- @IVar@.
 get (IVar v) = do

--- a/monad-par/Control/Monad/Par/Scheds/Direct.hs
+++ b/monad-par/Control/Monad/Par/Scheds/Direct.hs
@@ -445,7 +445,7 @@ new  = io$ do r <- newIORef Empty
               return (IVar r)
 
 {-# INLINE get  #-}
--- | Read the value in an @IVar@.  The 'get' can only return when the
+-- | Read the value in an @IVar@.  The 'get' operation can only return when the
 -- value has been written by a prior or parallel @put@ to the same
 -- @IVar@.
 get (IVar vr) =  do

--- a/monad-par/Control/Monad/Par/Scheds/Direct.hs
+++ b/monad-par/Control/Monad/Par/Scheds/Direct.hs
@@ -445,7 +445,7 @@ new  = io$ do r <- newIORef Empty
               return (IVar r)
 
 {-# INLINE get  #-}
--- | read the value in a @IVar@.  The 'get' can only return when the
+-- | read the value in an @IVar@.  The 'get' can only return when the
 -- value has been written by a prior or parallel @put@ to the same
 -- @IVar@.
 get (IVar vr) =  do

--- a/monad-par/Control/Monad/Par/Scheds/Direct.hs
+++ b/monad-par/Control/Monad/Par/Scheds/Direct.hs
@@ -439,13 +439,13 @@ baseSessionID = 1000
 --------------------------------------------------------------------------------
 
 {-# INLINE new  #-}
--- | creates a new @IVar@
+-- | Creates a new @IVar@
 new :: Par (IVar a)
 new  = io$ do r <- newIORef Empty
               return (IVar r)
 
 {-# INLINE get  #-}
--- | read the value in an @IVar@.  The 'get' can only return when the
+-- | Read the value in an @IVar@.  The 'get' can only return when the
 -- value has been written by a prior or parallel @put@ to the same
 -- @IVar@.
 get (IVar vr) =  do

--- a/monad-par/Control/Monad/Par/Scheds/TraceInternal.hs
+++ b/monad-par/Control/Monad/Par/Scheds/TraceInternal.hs
@@ -275,7 +275,7 @@ newFull x = deepseq x (Par $ New (Full x))
 newFull_ :: a -> Par (IVar a)
 newFull_ !x = Par $ New (Full x)
 
--- | read the value in a @IVar@.  The 'get' can only return when the
+-- | read the value in an @IVar@.  The 'get' can only return when the
 -- value has been written by a prior or parallel @put@ to the same
 -- @IVar@.
 get :: IVar a -> Par a
@@ -285,7 +285,7 @@ get v = Par $ \c -> Get v c
 put_ :: IVar a -> a -> Par ()
 put_ v !a = Par $ \c -> Put v a (c ())
 
--- | put a value into a @IVar@.  Multiple 'put's to the same @IVar@
+-- | put a value into an @IVar@.  Multiple 'put's to the same @IVar@
 -- are not allowed, and result in a runtime error.
 --
 -- 'put' fully evaluates its argument, which therefore must be an

--- a/monad-par/Control/Monad/Par/Scheds/TraceInternal.hs
+++ b/monad-par/Control/Monad/Par/Scheds/TraceInternal.hs
@@ -263,29 +263,29 @@ runParAsync = unsafePerformIO . runPar_internal False
 
 -- -----------------------------------------------------------------------------
 
--- | creates a new @IVar@
+-- | Creates a new @IVar@
 new :: Par (IVar a)
 new  = Par $ New Empty
 
--- | creates a new @IVar@ that contains a value
+-- | Creates a new @IVar@ that contains a value
 newFull :: NFData a => a -> Par (IVar a)
 newFull x = deepseq x (Par $ New (Full x))
 
--- | creates a new @IVar@ that contains a value (head-strict only)
+-- | Creates a new @IVar@ that contains a value (head-strict only)
 newFull_ :: a -> Par (IVar a)
 newFull_ !x = Par $ New (Full x)
 
--- | read the value in an @IVar@.  The 'get' can only return when the
+-- | Read the value in an @IVar@.  The 'get' can only return when the
 -- value has been written by a prior or parallel @put@ to the same
 -- @IVar@.
 get :: IVar a -> Par a
 get v = Par $ \c -> Get v c
 
--- | like 'put', but only head-strict rather than fully-strict.
+-- | Like 'put', but only head-strict rather than fully-strict.
 put_ :: IVar a -> a -> Par ()
 put_ v !a = Par $ \c -> Put v a (c ())
 
--- | put a value into an @IVar@.  Multiple 'put's to the same @IVar@
+-- | Put a value into an @IVar@.  Multiple 'put's to the same @IVar@
 -- are not allowed, and result in a runtime error.
 --
 -- 'put' fully evaluates its argument, which therefore must be an

--- a/monad-par/Control/Monad/Par/Scheds/TraceInternal.hs
+++ b/monad-par/Control/Monad/Par/Scheds/TraceInternal.hs
@@ -275,7 +275,7 @@ newFull x = deepseq x (Par $ New (Full x))
 newFull_ :: a -> Par (IVar a)
 newFull_ !x = Par $ New (Full x)
 
--- | Read the value in an @IVar@.  The 'get' can only return when the
+-- | Read the value in an @IVar@.  The 'get' operation can only return when the
 -- value has been written by a prior or parallel @put@ to the same
 -- @IVar@.
 get :: IVar a -> Par a

--- a/monad-par/Control/Monad/Par_Strawman.hs
+++ b/monad-par/Control/Monad/Par_Strawman.hs
@@ -89,7 +89,7 @@ spawn_ p = do
   fork (p >>= put_ r)
   return r
 
--- | Like 'fork', but returns a @IVar@ that can be used to query the
+-- | Like 'fork', but returns an @IVar@ that can be used to query the
 -- result of the forked computataion.
 spawn :: NFData a => Par a -> Par (IVar a)
 spawn p = do


### PR DESCRIPTION
This PR has contains 4 commits improving the Haddocks for monad-par:

1. Change "a IVar" to "an IVar"
2. Fix the duplicate documentation problem (Closes #40)
    * The cause of this was that the module exports as well as the original function definitions were using Haddock syntax. I just removed the Haddock markers (`-- |`) from the function export list, but left the comments intact otherwise. Some functions are still documented from the export list because they weren't documented in the original functions.
3. Consistently capitalize the beginning of Haddock comments
4. Consistently say "the 'get' operation" rather than "the 'get'".

(The changes are split out into separate commits, so if you don't want some of the changes, it should be easy to cherry-pick out the ones you want, or I can easily remove the undesirable commits).