### PR TITLE
Canonicalise Applicative/Monad instances

### DIFF
--- a/monad-par/Control/Monad/Par/Scheds/Sparks.hs
+++ b/monad-par/Control/Monad/Par/Scheds/Sparks.hs
@@ -55,7 +55,7 @@ get (Future a) = a `pseq` return a
 -- <boilerplate>
 
 instance Monad Par where
-  return x = Done x
+  return = pure
   Done x >>= k = k x
 
 instance PC.ParFuture Future Par  where 
@@ -69,7 +69,7 @@ instance Functor Par where
 
 instance Applicative Par where
    (<*>) = ap
-   pure  = return
+   pure  = Done
 
 #ifdef NEW_GENERIC
 doio :: IO a -> Par a

--- a/monad-par/Control/Monad/Par/Scheds/TraceInternal.hs
+++ b/monad-par/Control/Monad/Par/Scheds/TraceInternal.hs
@@ -175,12 +175,12 @@ instance Functor Par where
     fmap f m = Par $ \c -> runCont m (c . f)
 
 instance Monad Par where
-    return a = Par ($ a)
+    return = pure
     m >>= k  = Par $ \c -> runCont m $ \a -> runCont (k a) c
 
 instance Applicative Par where
    (<*>) = ap
-   pure  = return
+   pure a = Par ($ a)
 
 newtype IVar a = IVar (IORef (IVarContents a))
 -- data IVar a = IVar (IORef (IVarContents a))


### PR DESCRIPTION
This canonical form makes code a bit more future proof