### PR TITLE
Fix deadlock in Direct scheduler

### DIFF
--- a/monad-par/Control/Monad/Par/Scheds/Direct.hs
+++ b/monad-par/Control/Monad/Par/Scheds/Direct.hs
@@ -677,7 +677,8 @@ steal mysched@Sched{ idle, scheds, rng, no=my_no } = do
                r <- modifyHotVar idle $ \is -> (m:is, is)
                if length r == numCapabilities - 1
                   then do
-                     when dbg$ printf " [%d]  | initiating shutdown\n" my_no
+                     when dbg$ printf " [%d]  | waking up all threads\n" my_no
+                     writeHotVarRaw idle []
                      mapM_ (\vr -> putMVar vr True) r
                   else do
                     done <- takeMVar m

--- a/monad-par/Control/Monad/Par/Scheds/Direct.hs
+++ b/monad-par/Control/Monad/Par/Scheds/Direct.hs
@@ -681,7 +681,9 @@ steal mysched@Sched{ idle, scheds, rng, no=my_no } = do
                      writeHotVarRaw idle []
                      mapM_ (\vr -> putMVar vr True) r
                   else do
-                    done <- takeMVar m
+                    (Session _ finRef):_ <- readIORef $ sessions mysched
+                    fin <- readIORef finRef
+                    done <- if fin then pure True else takeMVar m
                     if done
                        then do
                          when dbg$ printf " [%d]  | shutting down\n" my_no


### PR DESCRIPTION
I was playing around with applying my concurrency testing library, [dejafu](http://hackage.haskell.org/package/dejafu), to the direct scheduler and found I could reliably provoke a deadlock with a simple parallel filter.  I did some digging and think I found the cause.

However, I'm a little wary of saying "look! here is the root cause of the long-standing BlockedIndefinitelyOnMVar errors" for two reasons:

1. I worry I am misunderstanding the key bit of code, as once I figured out what was causing the deadlock, it looked obviously wrong to me (no offence intended to the author!); and

2. I haven't *actually* tested monad-par itself, but rather a version of it modified to use dejafu's concurrency abstraction.

So if I have misunderstood the code, or I have a bug in dejafu which is making things behave differently, then I have not found the cause.

With those caveats mentioned, here is the test case:

```haskell
example :: (MonadConc m, MonadIO m) => m Bool
example = do
    let p x = x `mod` 2 == 0
    let xs = [0..1] :: [Int]
    s <- PM.runParIO $ parfilter p xs
    pure (s == filter p xs)
  where
    parfilter _ []  = pure []
    parfilter f [x] = pure (if f x then [x] else [])
    parfilter f xs  = do
      let (as, bs) = halve xs
      v1 <- PM.spawn $ parfilter f as
      v2 <- PM.spawn $ parfilter f bs
      left  <- PM.get v1
      right <- PM.get v2
      pure (left ++ right)

    halve xs = splitAt (length xs `div` 2) xs
```

With this, I can reliably observe a deadlock in dejafu in 150 pseudo-random executions (initialised with a fixed seed).

And here is the bit of monad-par which I think is problematic: https://github.com/simonmar/monad-par/blob/e73c50bdd42a0da3754ab9dec57e3c196dc1db19/monad-par/Control/Monad/Par/Scheds/Direct.hs#L675-L691

In the dejafu execution trace, I see this pattern before each thread blocks (annotated):

```
(Continue, NewMVar 4)                -- m <- newEmptyMVar
(Continue, ModCRef 4)                -- modifyHotVar idle
(Continue, GetNumCapabilities 2)     -- I replaced numCapabilities with calls to getNumCapabilities
(Continue, BlockedTakeMVar 4)        -- takeMVar m
```

Which corresponds to the `go` function when `length r /= numCapabilities - 1`.  How can every thread reach that `if` with the condition being false?  Simple: the `idle` list is never emptied.  So a deadlock arises if this happens:

1. `n - 1` threads add themselves to the list and block.
2. The `n`th thread adds itself to the list, and wakes up the other threads *but does not empty the list*.
3. `n - 1` threads add themselves to the list and block again.
4. The `n`th thread adds itself to the list, *and does not trigger the wake-up logic because the list is not the right length* and also blocks.
5. Every thread is now blocked.

So this PR empties the `idle` list before waking every blocked thread.  I have now run this 1,000,000 times with dejafu without observing a deadlock.

@rrnewton You wrote this code, although several years ago now, what do you think?