### PR TITLE
Add MonadFix instances

### DIFF
--- a/monad-par/Control/Monad/Par/IO.hs
+++ b/monad-par/Control/Monad/Par/IO.hs
@@ -19,10 +19,11 @@ import qualified Control.Monad.Par.Scheds.TraceInternal as Internal
 import Control.Monad.Par.Class
 import Control.Applicative
 import Control.Monad.Trans (liftIO, MonadIO)
+import Control.Monad.Fix (MonadFix)
 
 -- | A wrapper around an underlying Par type which allows IO.
 newtype ParIO a = ParIO (Par a)
-  deriving (Functor, Applicative, Monad, ParFuture IVar, ParIVar IVar)
+  deriving (Functor, Applicative, Monad, ParFuture IVar, ParIVar IVar, MonadFix)
 
 -- | A run method which allows actual IO to occur on top of the Par
 --   monad.  Of course this means that all the normal problems of

--- a/monad-par/Control/Monad/Par/Scheds/Direct.hs
+++ b/monad-par/Control/Monad/Par/Scheds/Direct.hs
@@ -26,7 +26,7 @@ module Control.Monad.Par.Scheds.Direct (
     new, get, put_, fork,
     newFull, newFull_, put,
     spawn, spawn_, spawnP,
-    spawn1_
+    spawn1_, fixPar, FixParException (..)
 --   runParAsync, runParAsyncHelper,
 --   yield,
  ) where
@@ -45,7 +45,8 @@ import qualified       Control.Monad.Par.Class  as PC
 import qualified       Control.Monad.Par.Unsafe as UN
 import                 Control.Monad.Par.Scheds.DirectInternal
                        (Par(..), Sched(..), HotVar, SessionID, Session(Session),
-                        newHotVar, readHotVar, modifyHotVar, modifyHotVar_, writeHotVarRaw)
+                        newHotVar, readHotVar, modifyHotVar, modifyHotVar_,
+                        writeHotVarRaw, fixPar, FixParException (..))
 #ifdef NEW_GENERIC
 import qualified       Control.Par.Class as PN
 import qualified       Control.Par.Class.Unsafe as PU

--- a/monad-par/Control/Monad/Par/Scheds/DirectInternal.hs
+++ b/monad-par/Control/Monad/Par/Scheds/DirectInternal.hs
@@ -54,6 +54,11 @@ instance MonadFix Par where
 -- the definition of 'mfix' for 'Par'. Throws 'FixParException'
 -- if the result is demanded strictly within the computation.
 fixPar :: (a -> Par a) -> Par a
+-- We do this IO-style, rather than ST-style, in order to get a
+-- consistent exception type. Using the ST-style mfix, a strict
+-- argument could lead us to *either* a <<loop>> exception *or*
+-- (if the wrong sort of computation gets re-run) a "multiple-put"
+-- error.
 fixPar f = Par $ ContT $ \ar -> RD.ReaderT $ \sched -> do
   mv <- newEmptyMVar
   ans <- unsafeDupableInterleaveIO (readMVar mv `catch`

--- a/monad-par/Control/Monad/Par/Scheds/Sparks.hs
+++ b/monad-par/Control/Monad/Par/Scheds/Sparks.hs
@@ -76,9 +76,10 @@ instance MonadFix Par where
    mfix = fixPar
 
 -- | Take the monadic fixpoint of a 'Par' computation. This is
--- the definition of 'mfix' for 'Par'. Currently, this throws
--- a @<<loop>>@ exception if the result is demanded strictly within
--- the computation, but that may change in a future release.
+-- the definition of 'mfix' for 'Par'. This throws
+-- an exception if the result is demanded strictly within
+-- the computation, but the implementation does not currently
+-- guarantee precisely which exception that will be.
 fixPar :: (a -> Par a) -> Par a
 fixPar f =
   let fr = f (case fr of Done x -> x)

--- a/monad-par/Control/Monad/Par/Scheds/Sparks.hs
+++ b/monad-par/Control/Monad/Par/Scheds/Sparks.hs
@@ -76,10 +76,7 @@ instance MonadFix Par where
    mfix = fixPar
 
 -- | Take the monadic fixpoint of a 'Par' computation. This is
--- the definition of 'mfix' for 'Par'. This throws
--- an exception if the result is demanded strictly within
--- the computation, but the implementation does not currently
--- guarantee precisely which exception that will be.
+-- the definition of 'mfix' for 'Par'.
 fixPar :: (a -> Par a) -> Par a
 fixPar f =
   let fr = f (case fr of Done x -> x)

--- a/monad-par/Control/Monad/Par/Scheds/Sparks.hs
+++ b/monad-par/Control/Monad/Par/Scheds/Sparks.hs
@@ -8,7 +8,7 @@ module Control.Monad.Par.Scheds.Sparks
  (
    Par(..), Future(..),
    runPar, 
-   get, spawn, spawn_, spawnP
+   get, spawn, spawn_, spawnP, fixPar
  ) 
 where 
 
@@ -17,6 +17,7 @@ import Control.Monad
 import Control.DeepSeq
 import Control.Parallel
 import qualified Control.Monad.Par.Class as PC
+import Control.Monad.Fix (MonadFix (mfix))
 -- import Control.Parallel.Strategies (rpar)
 
 #ifdef NEW_GENERIC
@@ -70,6 +71,18 @@ instance Functor Par where
 instance Applicative Par where
    (<*>) = ap
    pure  = Done
+
+instance MonadFix Par where
+   mfix = fixPar
+
+-- | Take the monadic fixpoint of a 'Par' computation. This is
+-- the definition of 'mfix' for 'Par'. Currently, this throws
+-- a @<<loop>>@ exception if the result is demanded strictly within
+-- the computation, but that may change in a future release.
+fixPar :: (a -> Par a) -> Par a
+fixPar f =
+  let fr = f (case fr of Done x -> x)
+  in fr
 
 #ifdef NEW_GENERIC
 doio :: IO a -> Par a

--- a/monad-par/Control/Monad/Par/Scheds/Trace.hs
+++ b/monad-par/Control/Monad/Par/Scheds/Trace.hs
@@ -14,7 +14,7 @@
 module Control.Monad.Par.Scheds.Trace (
     Par, runPar, runParIO, fork,
     IVar, new, newFull, newFull_, get, put, put_,
-    spawn, spawn_, spawnP
+    spawn, spawn_, spawnP, fixPar, FixParException (..)
   ) where
 
 import qualified Control.Monad.Par.Class as PC


### PR DESCRIPTION
Add `MonadFix` instances for the `Direct`, `Sparks`, and `Trace`
versions of `Par`.

Closes #46