### PR TITLE
Make NFData instances force IVar wrappers

### DIFF
--- a/monad-par/Control/Monad/Par/Scheds/ContFree.hs
+++ b/monad-par/Control/Monad/Par/Scheds/ContFree.hs
@@ -245,8 +245,8 @@ rand ref = uniformR (0, numCapabilities-1) =<< readHotVar ref
 -- Running computations in the Par monad
 --------------------------------------------------------------------------------
 
--- instance NFData (IVar a) where
---   rnf _ = ()
+instance NFData (IVar a) where
+   rnf !_ = ()
 
 runPar userComp = unsafePerformIO $ do
    allscheds <- makeScheds

--- a/monad-par/Control/Monad/Par/Scheds/Direct.hs
+++ b/monad-par/Control/Monad/Par/Scheds/Direct.hs
@@ -245,7 +245,7 @@ rand ref = Random.uniformR (0, numCapabilities-1) =<< readHotVar ref
 --------------------------------------------------------------------------------
 
 instance NFData (IVar a) where
-  rnf _ = ()
+  rnf !_ = ()
 
 {-# NOINLINE runPar #-}
 runPar = unsafePerformIO . runParIO

--- a/monad-par/Control/Monad/Par/Scheds/TraceInternal.hs
+++ b/monad-par/Control/Monad/Par/Scheds/TraceInternal.hs
@@ -189,9 +189,8 @@ newtype IVar a = IVar (IORef (IVarContents a))
 instance Eq (IVar a) where
   (IVar r1) == (IVar r2) = r1 == r2
 
--- Forcing evaluation of a IVar is fruitless.
 instance NFData (IVar a) where
-  rnf _ = ()
+  rnf !_ = ()
 
 
 -- From outside the Par computation we can peek.  But this is nondeterministic.


### PR DESCRIPTION
Previously, `NFData (IVar a)` instances would just define

    rnf _ = ()

This seems really strange, since `rnf undefined` will be `()`.
Change that to

    rnf !_ = ()