### PR TITLE
Reduce allocation in the Trace scheduler

### DIFF
--- a/monad-par/Control/Monad/Par/Scheds/Trace.hs
+++ b/monad-par/Control/Monad/Par/Scheds/Trace.hs
@@ -19,6 +19,8 @@ module Control.Monad.Par.Scheds.Trace (
 
 import qualified Control.Monad.Par.Class as PC
 import Control.Monad.Par.Scheds.TraceInternal
+  ( IVar, Par (..), Trace (..), get, new, put
+  , put_, newFull, newFull_, runCont, runPar, runParIO)
 import Control.DeepSeq
 import Control.Monad as M hiding (mapM, sequence, join)
 import Prelude hiding (mapM, sequence, head,tail)


### PR DESCRIPTION
* Unbox `MVar`s and `IVar`s all over the place.

* Restructure `IVarContents` to avoid extra allocation.

* Reduce the use of `atomicModifyIORef` somewhat.