### PR TITLE
Remove orphan instances

### DIFF
--- a/monad-par/Control/Monad/Par/Scheds/ContFree.hs
+++ b/monad-par/Control/Monad/Par/Scheds/ContFree.hs
@@ -163,8 +163,8 @@ modifyHotVar  = atomicModifyIORef
 modifyHotVar_ v fn = atomicModifyIORef v (\a -> (fn a, ()))
 readHotVar    = readIORef
 writeHotVar   = writeIORef
-instance Show (IORef a) where
-  show ref = "<ioref>"
+--instance Show (IORef a) where
+--  show ref = "<ioref>"
 
 -- hotVarTransaction = id
 hotVarTransaction = error "Transactions not currently possible for IO refs"
@@ -181,8 +181,8 @@ modifyHotVar  v fn = modifyMVar  v (return . fn)
 modifyHotVar_ v fn = modifyMVar_ v (return . fn)
 readHotVar    = readMVar
 writeHotVar v x = do swapMVar v x; return ()
-instance Show (MVar a) where
-  show ref = "<mvar>"
+--instance Show (MVar a) where
+--  show ref = "<mvar>"
 
 -- hotVarTransaction = id
 -- We could in theory do this by taking the mvar to grab the lock.
@@ -204,8 +204,8 @@ modifyHotVar  tv fn = atomically (do x <- readTVar tv
 modifyHotVar_ tv fn = atomically (do x <- readTVar tv; writeTVar tv (fn x))
 readHotVar x = atomically $ readTVar x
 writeHotVar v x = atomically $ writeTVar v x
-instance Show (TVar a) where
-  show ref = "<tvar>"
+--instance Show (TVar a) where
+--  show ref = "<tvar>"
 
 hotVarTransaction = atomically
 readHotVarRaw  = readTVar

--- a/monad-par/Control/Monad/Par/Scheds/DirectInternal.hs
+++ b/monad-par/Control/Monad/Par/Scheds/DirectInternal.hs
@@ -108,8 +108,8 @@ modifyHotVar  = atomicModifyIORef
 modifyHotVar_ v fn = atomicModifyIORef v (\a -> (fn a, ()))
 readHotVar    = readIORef
 writeHotVar   = writeIORef
-instance Show (IORef a) where
-  show _ref = "<ioref>"
+--instance Show (IORef a) where
+--  show _ref = "<ioref>"
 
 writeHotVarRaw :: HotVar a -> a -> IO ()
 -- hotVarTransaction = id
@@ -128,8 +128,8 @@ modifyHotVar  v fn = modifyMVar  v (return . fn)
 modifyHotVar_ v fn = modifyMVar_ v (return . fn)
 readHotVar    = readMVar
 writeHotVar v x = do swapMVar v x; return ()
-instance Show (MVar a) where
-  show _ref = "<mvar>"
+--instance Show (MVar a) where
+--  show _ref = "<mvar>"
 
 -- hotVarTransaction = id
 -- We could in theory do this by taking the mvar to grab the lock.
@@ -151,8 +151,8 @@ modifyHotVar  tv fn = atomically (do x <- readTVar tv
 modifyHotVar_ tv fn = atomically (do x <- readTVar tv; writeTVar tv (fn x))
 readHotVar x = atomically $ readTVar x
 writeHotVar v x = atomically $ writeTVar v x
-instance Show (TVar a) where
-  show ref = "<tvar>"
+--instance Show (TVar a) where
+--  show ref = "<tvar>"
 
 hotVarTransaction = atomically
 readHotVarRaw  = readTVar


### PR DESCRIPTION
For some reason, the `Direct` module has been exporting
orphan `Show` instances for standard types, which is
pretty awful. Let's just not.