### PR TITLE
Make the Direct module expose less

### DIFF
--- a/monad-par/Control/Monad/Par/Scheds/Direct.hs
+++ b/monad-par/Control/Monad/Par/Scheds/Direct.hs
@@ -18,9 +18,8 @@
 -- trace data structure).
 
 module Control.Monad.Par.Scheds.Direct (
-   Sched(..),
    Par, -- abstract: Constructor not exported.
-   IVar(..), IVarContents(..),
+   IVar,
 --    sched,
     runPar, runParIO,
     new, get, put_, fork,
@@ -458,7 +457,7 @@ get (IVar vr) =  do
        case e of
           Full a -> return a
           _ -> do
-            sch <- RD.ask
+            sch <- Par RD.ask
 #  ifdef DEBUG_DIRECT
             sn <- io$ makeStableName vr  -- Should probably do the MutVar inside...
             let resched = trace (" ["++ show (no sch) ++ "]  - Rescheduling on unavailable ivar "++show (hashStableName sn)++"!")
@@ -490,7 +489,7 @@ unsafePeek (IVar v) = do
 -- | @put_@ is a version of @put@ that is head-strict rather than fully-strict.
 --   In this scheduler, puts immediately execute woken work in the current thread.
 put_ (IVar vr) !content = do
-   sched <- RD.ask
+   sched <- Par RD.ask
    ks <- io$ do
       ks <- atomicModifyIORef vr $ \e -> case e of
                Empty      -> (Full content, [])
@@ -512,7 +511,7 @@ put_ (IVar vr) !content = do
 {-# INLINE unsafeTryPut #-}
 unsafeTryPut (IVar vr) !content = do
    -- Head strict rather than fully strict.
-   sched <- RD.ask
+   sched <- Par RD.ask
    (ks,res) <- io$ do
       pr <- atomicModifyIORef vr $ \e -> case e of
                    Empty      -> (Full content, ([], content))
@@ -577,7 +576,7 @@ fork task =
   -- fork rather than the task argument for stealing:
   case _FORKPARENT of
     True -> do
-      sched <- RD.ask
+      sched <- Par RD.ask
       callCC$ \parent -> do
          let wrapped = parent ()
          io$ pushWork sched wrapped
@@ -589,12 +588,12 @@ fork task =
          io$ printf " !!! ERROR: Should never reach this point #1\n"
 
       when dbg$ do
-       sched2 <- RD.ask
+       sched2 <- Par RD.ask
        io$ printf "  -  called parent continuation... was on worker [%d] now on worker [%d]\n" (no sched) (no sched2)
        return ()
 
     False -> do
-      sch <- RD.ask
+      sch <- Par RD.ask
       when dbg$ io$ printf " [%d] forking task...\n" (no sch)
       io$ pushWork sch task
 

--- a/monad-par/Control/Monad/Par/Scheds/DirectInternal.hs
+++ b/monad-par/Control/Monad/Par/Scheds/DirectInternal.hs
@@ -38,7 +38,7 @@ import Data.Concurrent.Deque.ChaseLev as R
 -- computations return nothing.
 --
 newtype Par a = Par { unPar :: C.ContT () ROnly a }
-    deriving (Functor, Applicative, Monad, MonadCont, RD.MonadReader Sched)
+    deriving (Functor, Applicative, Monad, MonadCont)
 type ROnly = RD.ReaderT Sched IO
 
 type SessionID = Word64
@@ -108,8 +108,6 @@ modifyHotVar  = atomicModifyIORef
 modifyHotVar_ v fn = atomicModifyIORef v (\a -> (fn a, ()))
 readHotVar    = readIORef
 writeHotVar   = writeIORef
-instance Show (IORef a) where
-  show _ref = "<ioref>"
 
 writeHotVarRaw :: HotVar a -> a -> IO ()
 -- hotVarTransaction = id
@@ -128,8 +126,6 @@ modifyHotVar  v fn = modifyMVar  v (return . fn)
 modifyHotVar_ v fn = modifyMVar_ v (return . fn)
 readHotVar    = readMVar
 writeHotVar v x = do swapMVar v x; return ()
-instance Show (MVar a) where
-  show _ref = "<mvar>"
 
 -- hotVarTransaction = id
 -- We could in theory do this by taking the mvar to grab the lock.
@@ -151,8 +147,6 @@ modifyHotVar  tv fn = atomically (do x <- readTVar tv
 modifyHotVar_ tv fn = atomically (do x <- readTVar tv; writeTVar tv (fn x))
 readHotVar x = atomically $ readTVar x
 writeHotVar v x = atomically $ writeTVar v x
-instance Show (TVar a) where
-  show ref = "<tvar>"
 
 hotVarTransaction = atomically
 readHotVarRaw  = readTVar


### PR DESCRIPTION
* Don't expose schedules (or the related `MonadReader` instance)
  from `.Direct`.

* Don't expose `IVar` implementation details from there either.

* Eliminate the orphan `Show` instances from there.