### PR TITLE
Tweak things to build with GHC-7.x

### DIFF
--- a/monad-par/monad-par.cabal
+++ b/monad-par/monad-par.cabal
@@ -165,7 +165,7 @@ Test-Suite test-monad-par
     hs-source-dirs: tests/ ./    
     -- Run tests in parallel:
     ghc-options: -O2 -threaded -rtsopts -with-rtsopts=-N4    
-    build-depends: base >= 4 && < 5
+    build-depends: base >= 4.3 && < 5
                  , abstract-par, monad-par-extras
                  , array   >= 0.3
                  , deepseq >= 1.2


### PR DESCRIPTION
- import liftIO from Control.Monad.Trans (from mtl), thus we can avoid
  direct dependency on transformers
- Fix imports around unsafeInterleaveIO
- Typeable needs to be explicitly derived, newer GHCs accept that fine
  too

Builds with ghc-7.0.4 ... ghc-8.8.1 on my machine