### PR TITLE
Port tests to Tasty framework

### DIFF
--- a/monad-par/monad-par.cabal
+++ b/monad-par/monad-par.cabal
@@ -171,10 +171,8 @@ Test-Suite test-monad-par
                  , deepseq >= 1.2
                  , time
                  , QuickCheck, HUnit
-                 , test-framework-hunit
-                 , test-framework-quickcheck2 >= 0.3 
-                 , test-framework, test-framework-th
-
+                 , tasty, tasty-hunit
+                 , tasty-quickcheck, tasty-th
                  , abstract-deque >= 0.1.4
                  , mwc-random >= 0.11
                  , mtl >= 2.0.1.0

--- a/monad-par/tests/AListTest.hs
+++ b/monad-par/tests/AListTest.hs
@@ -1,10 +1,9 @@
 
 module AListTest ( tests ) where
 
-import Test.Framework (defaultMain, testGroup)
-import Test.Framework.Providers.HUnit
-import Test.Framework.Providers.QuickCheck2 (testProperty)
-import Test.HUnit
+import Test.Tasty (defaultMain, testGroup)
+import Test.Tasty.HUnit
+import Test.Tasty.QuickCheck (testProperty)
 import Test.QuickCheck
 
 import Control.Monad.Par.AList as A
@@ -53,7 +52,7 @@ showDbg (AList  l)   = show l
 
 --------------------------------------------------------------------------------
 
-tests = [
+tests = testGroup "AList Tests" [
   -- testGroup "AList HUnit Tests" (hUnitTestToTests alist_tests),
 
   testGroup "AList HUnit Tests" [

--- a/monad-par/tests/AllTests.hs
+++ b/monad-par/tests/AllTests.hs
@@ -3,13 +3,13 @@
 
 module Main where 
 
-import Test.Framework (defaultMain, testGroup)
+import Test.Tasty (defaultMain, testGroup)
 import qualified AListTest 
 import qualified AsyncTest
 import qualified ParTests1
 import qualified ParTests2
 
-main = defaultMain $ concat $ 
+main = defaultMain $ testGroup "All monad-par tests"
        [ AListTest.tests
        , ParTests1.tests
 --       , ParTests2.tests -- [2013.09.08] Temporarily disabling till we get back to debugging Direct.

--- a/monad-par/tests/AsyncTest.hs
+++ b/monad-par/tests/AsyncTest.hs
@@ -5,9 +5,9 @@ module AsyncTest (tests, manual_main) where
 import Control.Exception 
 import Control.Monad.Par.Scheds.Trace
 import Control.Monad.Par.Scheds.TraceInternal (Par(..),Trace(Fork),runCont,runParAsync)
-import Test.Framework.TH (testGroupGenerator)
-import Test.Framework (defaultMain, testGroup)
-import Test.Framework.Providers.HUnit
+import Test.Tasty.TH (testGroupGenerator)
+import Test.Tasty (defaultMain, testGroup)
+import Test.Tasty.HUnit
 
 import TestHelpers
 

--- a/monad-par/tests/ParTests_shared.hs
+++ b/monad-par/tests/ParTests_shared.hs
@@ -5,11 +5,10 @@ import GHC.Conc (numCapabilities)
 import Control.Exception (evaluate)
 -- import System.IO.Unsafe
 -- import Data.IORef
-import Test.HUnit        (Assertion, (@=?))
-import Test.Framework.TH (testGroupGenerator)
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.TH     (testGroupGenerator)
 -- import Test.Framework (defaultMain, testGroup)
-import qualified Test.Framework as TF
-import           Test.Framework.Providers.HUnit 
 -- import Test.Framework.Providers.QuickCheck2 (testProperty)
 import System.Timeout (timeout)
 
@@ -201,6 +200,6 @@ disabled_case_async_test1 =
 
 ------------------------------------------------------------
 
-tests :: [TF.Test]
-tests = [ $(testGroupGenerator) ]
+tests :: TestTree
+tests = $(testGroupGenerator)
 


### PR DESCRIPTION
The test-framework ecosystem [doesn't work since GHC 8.10](https://github.com/haskell-infra/hackage-trustees/issues/323#issuecomment-980729413). This PR ports the tests to Tasty, which is popular and maintained, and has a very similar API.

Thanks for your work on the library. It is very useful.