### PR TITLE
fix typos

### DIFF
--- a/Experimental/monad-par-transformers/Control/Monad/Par/Engines/Internal.hs
+++ b/Experimental/monad-par-transformers/Control/Monad/Par/Engines/Internal.hs
@@ -33,7 +33,7 @@ import Debug.Trace
 -- Types
 --------------------------------------------------------------------------------
 
--- Co-routines built on IVars communitate by passing IVars back and forth.  For the
+-- Co-routines built on IVars communicate by passing IVars back and forth.  For the
 -- parallel engine abstraction, we communication is between parent and child
 -- threads. Each time an engine checks in with its parent it gets both more fuel and
 -- another IVar to use for the next round.
@@ -76,7 +76,7 @@ data EngCheckin = Finished [OutStanding]
                  -- fuel.  Still return any children.
 
 -- | Outstanding threads, on the other hand, may or may not be finished with their
--- work; we find out when they checkin.
+-- work; we find out when they check in.
 newtype OutStanding = OutStanding (P.IVar EngCheckin)
 
 -- | An engine result may or may not be ready yet.  Either way it returns handles for

--- a/examples/src/minimax/Prog.hs
+++ b/examples/src/minimax/Prog.hs
@@ -10,7 +10,7 @@ import Tree
 import System.Random
 import Data.List
 
--- First arg decaffinates game
+-- First arg decaffeinates game
 prog :: Int -> String
 prog decaf = showMove (head game)
 	       --"OXO\n" ++

--- a/examples/src/simple/pleasantly_par.hs
+++ b/examples/src/simple/pleasantly_par.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE BangPatterns, OverloadedStrings #-}
 
--- Embarassingly parallel.
+-- Embarrassingly parallel.
 -- If this doesn't get a speedup nothing will!
 
 -- Note: This program is an example of a dependence on "put" being
@@ -39,7 +39,7 @@ work offset (!i) (!n) = work offset (i-1) (n + 1 / fromIntegral (i+offset))
 runit :: Int -> Int -> IO ()
 runit total partitions = evaluate $ runPar $ 
    do 
-      prnt$ "Running embarassingly parallel benchmark."
+      prnt$ "Running embarrassingly parallel benchmark."
       prnt$ "Running "++ show total ++" total iterations"
       prnt$ "Spawning "++show partitions++" tasks..."
       results <- mapM (spawn_ . kernel) [0 .. partitions-1] 

--- a/monad-par/Control/Monad/Par/IO.hs
+++ b/monad-par/Control/Monad/Par/IO.hs
@@ -27,7 +27,7 @@ newtype ParIO a = ParIO (Par a)
 
 -- | A run method which allows actual IO to occur on top of the Par
 --   monad.  Of course this means that all the normal problems of
---   parallel IO computations are present, including nondeterminsm.
+--   parallel IO computations are present, including nondeterminism.
 --
 --   A simple example program:
 --

--- a/monad-par/Control/Monad/Par/Scheds/Direct.hs
+++ b/monad-par/Control/Monad/Par/Scheds/Direct.hs
@@ -228,7 +228,7 @@ pushWork Sched { workpool, idle, no } task = do
 
 tryWakeIdle :: HotVar [MVar Bool] -> IO ()
 tryWakeIdle idle = do
--- NOTE: I worry about having the idle var hammmered by all threads on their spawn-path:
+-- NOTE: I worry about having the idle var hammered by all threads on their spawn-path:
   -- If any worker is idle, wake one up and give it work to do.
   idles <- readHotVar idle -- Optimistically do a normal read first.
   when (not (Prelude.null idles)) $ do
@@ -658,7 +658,7 @@ rescheduleR cnt kont = do
 -- | Attempt to steal work or, failing that, give up and go idle.
 --
 --   The current policy is to do a burst of of N tries without
---   yielding or pausing inbetween.
+--   yielding or pausing in between.
 steal :: Sched -> IO ()
 steal mysched@Sched{ idle, scheds, rng, no=my_no } = do
   when (dbglvl>=2)$ do tid <- myThreadId

--- a/monad-par/Control/Monad/Par/Scheds/DirectInternal.hs
+++ b/monad-par/Control/Monad/Par/Scheds/DirectInternal.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE PackageImports, CPP, GeneralizedNewtypeDeriving,
              DeriveDataTypeable #-}
 
--- | Type definiton and some helpers.  This is used mainly by
+-- | Type definition and some helpers.  This is used mainly by
 -- Direct.hs but can also be used by other modules that want access to
 -- the internals of the scheduler (i.e. the private `Par` type constructor).
 

--- a/monad-par/Control/Monad/Par_Strawman.hs
+++ b/monad-par/Control/Monad/Par_Strawman.hs
@@ -90,7 +90,7 @@ spawn_ p = do
   return r
 
 -- | Like 'fork', but returns an @IVar@ that can be used to query the
--- result of the forked computataion.
+-- result of the forked computation.
 spawn :: NFData a => Par a -> Par (IVar a)
 spawn p = do
   r <- new

--- a/monad-par/tests/TestHelpers.hs
+++ b/monad-par/tests/TestHelpers.hs
@@ -27,7 +27,7 @@ _waste_time n = loop n 1.00111
     loop !n !x             = loop (n-1) (x + x * 0.5011)
 
 -- This version watches the clock so it uses a constant amount of time
--- regadless of compile/interpret mode an opt lvl.
+-- regardless of compile/interpret mode an opt lvl.
 waste_time :: Double -> IO Double
 waste_time seconds = 
     do strt <- getCurrentTime


### PR DESCRIPTION
Experimental/monad-par-transformers/Control/Monad/Par/Engines/Internal.hs
examples/src/minimax/Prog.hs
examples/src/simple/pleasantly_par.hs
monad-par/Control/Monad/Par/IO.hs
monad-par/Control/Monad/Par/Scheds/Direct.hs
monad-par/Control/Monad/Par/Scheds/DirectInternal.hs
monad-par/Control/Monad/Par_Strawman.hs
monad-par/tests/TestHelpers.hs

<hr>

monad-par/tests/TestHelpers.hs
 
for another PR this line could be improved
 
monad-par/tests/TestHelpers.hs
 
```
-- regardless of compile/interpret mode an opt lvl.
```

