### PR TITLE
Fix outdated links in the doc of  `Control.Monad.Par` (#78)

### DIFF
--- a/monad-par/Control/Monad/Par.hs
+++ b/monad-par/Control/Monad/Par.hs
@@ -81,12 +81,11 @@
 
       * The wiki\/tutorial (<http://www.haskell.org/haskellwiki/Par_Monad:_A_Parallelism_Tutorial>)
 
-      * The original paper (<http://www.cs.indiana.edu/~rrnewton/papers/haskell2011_monad-par.pdf>)
+      * The original paper ( [S. Marlow,R. Newton,and S. P. Jones, "A Monad for Deterministic Parallelism,"in Proceedings of the Fourth ACM SIGPLAN Symposium on Haskell, Tokyo, Japan, ACM, 2011, pp. 71-82](http://simonmar.github.io/bib/papers/monad-par.pdf) )
 
-      * Tutorial slides (<http://community.haskell.org/~simonmar/slides/CUFP.pdf>)
+      * Tutorial slides (<https://www.cse.unt.edu/~tarau/teaching/parpro/papers/CUFP.pdf>)
 
-      * Other slides: (<http://www.cs.ox.ac.uk/ralf.hinze/WG2.8/28/slides/simon.pdf>,
-                      <http://www.cs.indiana.edu/~rrnewton/talks/2011_HaskellSymposium_ParMonad.pdf>)
+      * Other slides: (<http://www.cs.ox.ac.uk/ralf.hinze/WG2.8/28/slides/simon.pdf>)
 
  -}
 


### PR DESCRIPTION
- For the paper,

use the `Links` markup instead of just `URL` markup,
add the paper's info with IEEE citation style,
replace the outdated link with the Mr.Marlow's pasted blog on `github.io`.

- For the slides, 

replace the outdated link with the link of a copy of source file in cse.unt.edu , 
remove the invalid link which seems cannot find the existed source.

***

I would apology if some of these changes will be offensive to someone. If there are any adjustments required, please feel free to point them out.

Below is the preview under the render of `haddock`:
<img width="817" alt="屏幕截图 2023-11-29 124349" src="https://github.com/simonmar/monad-par/assets/39958730/8c67129e-a015-482e-b094-c791235087bd">
